### PR TITLE
Fix renew and revoke lease

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -324,11 +324,50 @@ module.exports = {
   },
   renew: {
     method: 'PUT',
-    path: '/sys/renew/{{lease_id}}',
+    path: '/sys/leases/renew',
+    schema: {
+      req: {
+        type: 'object',
+        properties: {
+          lease_id: {
+            type: 'string',
+          },
+          increment: {
+            type: 'integer'
+          }
+        },
+        required: ['lease_id'],
+      },
+      res: {
+        type: 'object',
+        properties: {
+          lease_id: {
+            type: 'string',
+          },
+          renewable: {
+            type: 'boolean',
+          },
+          lease_duration: {
+            type: 'integer',
+          },
+        },
+      }
+    },
   },
   revoke: {
     method: 'PUT',
-    path: '/sys/revoke/{{lease_id}}',
+    path: '/sys/leases/revoke',
+    schema: {
+      req: {
+        type: 'object',
+        properties: {
+          lease_id: {
+            type: 'string',
+          },
+        },
+        required: ['lease_id'],
+      },
+    },
   },
   revokePrefix: {
     method: 'PUT',


### PR DESCRIPTION
According to vault API documentation the renew the lease_id should be include in the request body and not part of the URL.

See:
https://www.vaultproject.io/api/system/leases.html#renew-lease
https://www.vaultproject.io/api/system/leases.html#revoke-lease